### PR TITLE
USA Research Slot + Intervention Tree Changes

### DIFF
--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -414,7 +414,7 @@ focus_tree = {
 		available_if_capitulated = no
 		search_filters = {FOCUS_FILTER_RESEARCH}
 		completion_reward = {
-			add_research_slot = 2
+			add_research_slot = 3
 		}
 	}
 
@@ -687,7 +687,7 @@ focus_tree = {
 		prerequisite = { focus = USA_war_propaganda }
 		
 		relative_position_id = USA_war_propaganda
-		cost = 5
+		cost = 3
 
 		ai_will_do = {
 			factor = 1
@@ -742,7 +742,7 @@ focus_tree = {
 		x = -1
 		y = 2
 		relative_position_id = USA_war_propaganda
-		cost = 5
+		cost = 3
 		ai_will_do = {
 			factor = 1
 		}
@@ -770,7 +770,7 @@ focus_tree = {
 		prerequisite = { focus = USA_war_propaganda }
 	
 		relative_position_id = USA_war_propaganda
-		cost = 5
+		cost = 3
 
 		ai_will_do = {
 			factor = 1
@@ -808,7 +808,7 @@ focus_tree = {
 		y = 2
 		prerequisite = { focus = USA_focus_on_asia }
 		relative_position_id = USA_war_propaganda
-		cost = 5
+		cost = 3
 
 		ai_will_do = {
 			factor = 1
@@ -838,7 +838,7 @@ focus_tree = {
 		x = 1
 		y = 3
 		relative_position_id = USA_war_propaganda
-		cost = 5
+		cost = 3
 		ai_will_do = {
 			factor = 1
 		}
@@ -1355,7 +1355,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_research_slot = 3
+			add_research_slot = 2
 		}
 	}
 	


### PR DESCRIPTION
1 Research slot added to Scientific Research & Development Office. 1 Research slot removed from Extra Research Slot.
Total number of research slots remains static.

Intervention tree (focuses following War Economy but before Scientist Haven) shortened to 21 days.