### PR TITLE
Increasing Fuel Lend Lease Efficiency

### DIFF
--- a/common/defines/hip_defines.lua
+++ b/common/defines/hip_defines.lua
@@ -90,7 +90,7 @@ NDefines.NCountry.SPECIAL_FORCES_CAP_BASE = 0.03					-- Max ammount of special f
 NDefines.NCountry.SPECIAL_FORCES_CAP_MIN = 18					-- You can have a minimum of this many special forces battalions, regardless of the number of non-special forces battalions you have, this can also be modified by a country modifier
 NDefines.NCountry.BASE_FUEL_LAND_LEASE_SPEED = 50				-- base value for maximum fuel that can be land leased per hour
 NDefines.NCountry.FUEL_LAND_LEASE_RATIO = 1.0					-- multiplier for guel gain that is added to maximum fuel that can be land leased per hour
-NDefines.NCountry.FUEL_LEASE_CONVOY_RATIO = 0.0015				-- was 0.0005 -- num convoys needed per fuel land lease 
+NDefines.NCountry.FUEL_LEASE_CONVOY_RATIO = 0.0001				-- was 0.0005 -- num convoys needed per fuel land lease 
 
 
 


### PR DESCRIPTION
Previously Fuel Lend Lease was less effective than importing oil.
Importing oil gives 44 fuel per convoy per day
Fuel per convoy per day (when LL) increased from 3.7 to 58.8 (17 convoys for 1000 fuel)